### PR TITLE
Add speed/strength/control/synergy metadata to "description"

### DIFF
--- a/src/com/blueraja/magicduelsimporter/magicassist/Deck.java
+++ b/src/com/blueraja/magicduelsimporter/magicassist/Deck.java
@@ -10,6 +10,12 @@ public class Deck {
     private final String _name;
     private Map<CardData, Integer> _cards = new HashMap<>();
 
+    private float scoreSpeed;
+    private float scoreStrength;
+    private float scoreControl;
+    private float scoreSynergy;
+    private int onlineDeckNumber;
+
     public Deck(String name) {
         _name = name;
     }
@@ -44,5 +50,50 @@ public class Deck {
 
     public String getName() {
         return _name;
+    }
+
+    public float getScoreSpeed() {
+        return scoreSpeed;
+    }
+
+    public void setScoreSpeed(float scoreSpeed) {
+        this.scoreSpeed = scoreSpeed;
+    }
+
+    public float getScoreStrength() {
+        return scoreStrength;
+    }
+
+    public void setScoreStrength(float scoreStrength) {
+        this.scoreStrength = scoreStrength;
+    }
+
+    public float getScoreControl() {
+        return scoreControl;
+    }
+
+    public void setScoreControl(float scoreControl) {
+        this.scoreControl = scoreControl;
+    }
+
+    public float getScoreSynergy() {
+        return scoreSynergy;
+    }
+
+    public void setScoreSynergy(float scoreSynergy) {
+        this.scoreSynergy = scoreSynergy;
+    }
+
+    public int getOnlineDeckNumber() {
+        return onlineDeckNumber;
+    }
+
+    public void setOnlineDeckNumber(int onlineDeckNumber) {
+        this.onlineDeckNumber = onlineDeckNumber;
+    }
+
+    public String getDescription() {
+        return String.format("Speed: %.3f\nStrength: %.3f\nControl: %.3f\nSynergy: %.3f\nOnline Deck Number: %d",
+                getScoreSpeed(), getScoreStrength(), getScoreControl(), getScoreSynergy(), getOnlineDeckNumber());
     }
 }

--- a/src/com/blueraja/magicduelsimporter/magicassist/MagicAssistDeckManager.java
+++ b/src/com/blueraja/magicduelsimporter/magicassist/MagicAssistDeckManager.java
@@ -156,6 +156,10 @@ public class MagicAssistDeckManager {
         typeElement.setTextContent(isCollection ? "collection" : "deck");
         rootElement.appendChild(typeElement);
 
+        Element commentElement = doc.createElement("comment");
+        commentElement.setTextContent(isCollection ? "Magic Duels collection." : deck.getDescription());
+        rootElement.appendChild((commentElement));
+
         Element propertiesElement = doc.createElement("properties");
         rootElement.appendChild(propertiesElement);
 

--- a/src/com/blueraja/magicduelsimporter/magicduels/MagicDuelsDeckManager.java
+++ b/src/com/blueraja/magicduelsimporter/magicduels/MagicDuelsDeckManager.java
@@ -57,6 +57,13 @@ public class MagicDuelsDeckManager {
         for (int deckPos=0; deckPos<32; deckPos++) {
             MagicDuelsDeck magicDuelsDeck = profile.readDeck(deckPos);
             Deck deck = new Deck(magicDuelsDeck.name);
+
+            deck.setScoreSpeed(magicDuelsDeck.values[0]);
+            deck.setScoreStrength(magicDuelsDeck.values[1]);
+            deck.setScoreControl(magicDuelsDeck.values[2]);
+            deck.setScoreSynergy(magicDuelsDeck.values[3]);
+            deck.setOnlineDeckNumber(magicDuelsDeck.onlineDeckNumber);
+
             for (int i=0; i<100; i++) {
                 int cardId = magicDuelsDeck.cards[0][i];
                 int numCards = magicDuelsDeck.cards[1][i];


### PR DESCRIPTION
This is a simple change that adds Magic Duels speed/strength/control/synergy deck stats to Magic Assist deck "Description". 